### PR TITLE
Feat member(scrum 1)

### DIFF
--- a/backend/src/main/java/com/NBE3_4_2_Team4/Nbe342Team4Application.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/Nbe342Team4Application.java
@@ -5,9 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class Nbe342Team4Application {
-
 	public static void main(String[] args) {
 		SpringApplication.run(Nbe342Team4Application.class, args);
 	}

--- a/backend/src/main/java/com/NBE3_4_2_Team4/domain/member/member/controller/MemberController.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/domain/member/member/controller/MemberController.java
@@ -46,6 +46,7 @@ public class MemberController {
         return new RsData<>("200-1", "OK", token);
     }
 
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     @PostMapping("/api/logout")
     public RsData<Empty> logout(HttpServletResponse resp) {
         httpManager.deleteCookie(resp, "accessToken");

--- a/backend/src/main/java/com/NBE3_4_2_Team4/domain/member/member/controller/MemberController.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/domain/member/member/controller/MemberController.java
@@ -46,6 +46,31 @@ public class MemberController {
         return new RsData<>("200-1", "OK", token);
     }
 
+    @GetMapping("/api/test")
+    public ResponseEntity<Void> test12(){
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/api/products/test")
+    public ResponseEntity<Void> test22(){
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/api/questions/test")
+    public ResponseEntity<Void> test32(){
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/api/answers/test")
+    public ResponseEntity<Void> test42(){
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/api/admin/test")
+    public ResponseEntity<Void> test52(){
+        return ResponseEntity.ok().build();
+    }
+
     @PostMapping("/api/test")
     public ResponseEntity<Void> test1(){
         return ResponseEntity.ok().build();

--- a/backend/src/main/java/com/NBE3_4_2_Team4/domain/member/member/controller/MemberController.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/domain/member/member/controller/MemberController.java
@@ -6,7 +6,10 @@ import com.NBE3_4_2_Team4.global.exceptions.InValidPasswordException;
 import com.NBE3_4_2_Team4.global.rsData.RsData;
 import com.NBE3_4_2_Team4.global.security.HttpManager;
 import com.NBE3_4_2_Team4.standard.base.Empty;
+import io.micrometer.common.util.StringUtils;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,6 +29,12 @@ public class MemberController {
                         "400-2",
                         e.getMessage()
                 ));
+    }
+
+    @GetMapping("/")
+    public String home(HttpServletRequest request){
+        String token = httpManager.getCookieValue(request, "accessToken");
+        return StringUtils.isBlank(token) ?  "not logged in" : token;
     }
 
     @PostMapping("/api/login")

--- a/backend/src/main/java/com/NBE3_4_2_Team4/domain/member/member/controller/MemberController.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/domain/member/member/controller/MemberController.java
@@ -53,31 +53,6 @@ public class MemberController {
         return new RsData<>("204-1", "No Content");
     }
 
-    @GetMapping("/api/test")
-    public ResponseEntity<Void> test12(){
-        return ResponseEntity.ok().build();
-    }
-
-    @GetMapping("/api/products/test")
-    public ResponseEntity<Void> test22(){
-        return ResponseEntity.ok().build();
-    }
-
-    @GetMapping("/api/questions/test")
-    public ResponseEntity<Void> test32(){
-        return ResponseEntity.ok().build();
-    }
-
-    @GetMapping("/api/answers/test")
-    public ResponseEntity<Void> test42(){
-        return ResponseEntity.ok().build();
-    }
-
-    @GetMapping("/api/admin/test")
-    public ResponseEntity<Void> test52(){
-        return ResponseEntity.ok().build();
-    }
-
     @PostMapping("/api/test")
     public ResponseEntity<Void> test1(){
         return ResponseEntity.ok().build();

--- a/backend/src/main/java/com/NBE3_4_2_Team4/domain/member/member/controller/MemberController.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/domain/member/member/controller/MemberController.java
@@ -42,14 +42,14 @@ public class MemberController {
             @RequestBody LoginRequestDto loginRequestDto,
             HttpServletResponse resp) {
         String token = memberService.login(loginRequestDto);
-        httpManager.setCookie(resp, "accessToken", token, 30);
+        httpManager.setJwtCookie(resp, token, 30);
         return new RsData<>("200-1", "OK", token);
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PostMapping("/api/logout")
     public RsData<Empty> logout(HttpServletResponse resp) {
-        httpManager.deleteCookie(resp, "accessToken");
+        httpManager.expireJwtCookie(resp);
         return new RsData<>("204-1", "No Content");
     }
 

--- a/backend/src/main/java/com/NBE3_4_2_Team4/domain/member/member/controller/MemberController.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/domain/member/member/controller/MemberController.java
@@ -11,6 +11,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 public class MemberController {
+    private static final Logger log = LoggerFactory.getLogger(MemberController.class);
     private final MemberService memberService;
     private final HttpManager httpManager;
 

--- a/backend/src/main/java/com/NBE3_4_2_Team4/domain/member/member/controller/MemberController.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/domain/member/member/controller/MemberController.java
@@ -9,10 +9,7 @@ import com.NBE3_4_2_Team4.standard.base.Empty;
 import io.micrometer.common.util.StringUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -20,7 +17,6 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 public class MemberController {
-    private static final Logger log = LoggerFactory.getLogger(MemberController.class);
     private final MemberService memberService;
     private final HttpManager httpManager;
 

--- a/backend/src/main/java/com/NBE3_4_2_Team4/domain/member/member/controller/MemberController.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/domain/member/member/controller/MemberController.java
@@ -46,6 +46,12 @@ public class MemberController {
         return new RsData<>("200-1", "OK", token);
     }
 
+    @PostMapping("/api/logout")
+    public RsData<Empty> logout(HttpServletResponse resp) {
+        httpManager.deleteCookie(resp, "accessToken");
+        return new RsData<>("204-1", "No Content");
+    }
+
     @GetMapping("/api/test")
     public ResponseEntity<Void> test12(){
         return ResponseEntity.ok().build();

--- a/backend/src/main/java/com/NBE3_4_2_Team4/domain/member/member/entity/Member.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/domain/member/member/entity/Member.java
@@ -18,6 +18,7 @@ import java.util.List;
 @AllArgsConstructor
 @Entity
 @EntityListeners({AuditingEntityListener.class})
+@ToString
 public class Member {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/NBE3_4_2_Team4/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.NBE3_4_2_Team4.global.config;
 
+import com.NBE3_4_2_Team4.global.security.accessDeniedHandler.CustomAccessDeniedHandler;
 import com.NBE3_4_2_Team4.global.security.authenticationEntryPoint.CustomAuthenticationEntryPoint;
 import com.NBE3_4_2_Team4.global.security.filter.CustomJwtFilter;
 import com.NBE3_4_2_Team4.global.security.oauth2.CustomOAuth2SuccessHandler;
@@ -7,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -25,6 +25,8 @@ public class SecurityConfig {
     private final CustomJwtFilter customJwtFilter;
     private final CustomOAuth2SuccessHandler oAuth2SuccessHandler;
     private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
@@ -40,6 +42,7 @@ public class SecurityConfig {
                 .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))//h2-console 정상 작동용
                 .exceptionHandling(exception -> {
                     exception.authenticationEntryPoint(authenticationEntryPoint);
+                    exception.accessDeniedHandler(accessDeniedHandler);
                 })
                 .oauth2Login(
                         oauth2Login             ->

--- a/backend/src/main/java/com/NBE3_4_2_Team4/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/global/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.NBE3_4_2_Team4.global.config;
 
 import com.NBE3_4_2_Team4.global.security.filter.CustomJwtFilter;
+import com.NBE3_4_2_Team4.global.security.oauth2.CustomOAuth2SuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -20,7 +21,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final CustomJwtFilter customJwtFilter;
-
+    private final CustomOAuth2SuccessHandler oAuth2SuccessHandler;
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
@@ -35,9 +36,9 @@ public class SecurityConfig {
                 .addFilterBefore(customJwtFilter, UsernamePasswordAuthenticationFilter.class)
                 .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))//h2-console 정상 작동용
                 .oauth2Login(
-                        _             ->
+                        oauth2Login             ->
                         {
-
+                            oauth2Login.successHandler(oAuth2SuccessHandler);
                         }
                 )
         ;

--- a/backend/src/main/java/com/NBE3_4_2_Team4/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/global/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.NBE3_4_2_Team4.global.config;
 import com.NBE3_4_2_Team4.global.security.accessDeniedHandler.CustomAccessDeniedHandler;
 import com.NBE3_4_2_Team4.global.security.authenticationEntryPoint.CustomAuthenticationEntryPoint;
 import com.NBE3_4_2_Team4.global.security.filter.CustomJwtFilter;
+import com.NBE3_4_2_Team4.global.security.oauth2.CustomOAuth2RequestResolver;
 import com.NBE3_4_2_Team4.global.security.oauth2.CustomOAuth2SuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -24,6 +25,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final CustomJwtFilter customJwtFilter;
+    private final CustomOAuth2RequestResolver oAuth2RequestResolver;
     private final CustomOAuth2SuccessHandler oAuth2SuccessHandler;
     private final CustomAuthenticationEntryPoint authenticationEntryPoint;
     private final CustomAccessDeniedHandler accessDeniedHandler;
@@ -51,6 +53,8 @@ public class SecurityConfig {
                         oauth2Login             ->
                         {
                             oauth2Login.successHandler(oAuth2SuccessHandler);
+                            oauth2Login.authorizationEndpoint(authorizationEndpointConfig ->
+                                    authorizationEndpointConfig.authorizationRequestResolver(oAuth2RequestResolver));
                         }
                 )
         ;

--- a/backend/src/main/java/com/NBE3_4_2_Team4/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/global/config/SecurityConfig.java
@@ -1,11 +1,13 @@
 package com.NBE3_4_2_Team4.global.config;
 
+import com.NBE3_4_2_Team4.global.security.authenticationEntryPoint.CustomAuthenticationEntryPoint;
 import com.NBE3_4_2_Team4.global.security.filter.CustomJwtFilter;
 import com.NBE3_4_2_Team4.global.security.oauth2.CustomOAuth2SuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -22,6 +24,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
     private final CustomJwtFilter customJwtFilter;
     private final CustomOAuth2SuccessHandler oAuth2SuccessHandler;
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
@@ -35,6 +38,9 @@ public class SecurityConfig {
                         })
                 .addFilterBefore(customJwtFilter, UsernamePasswordAuthenticationFilter.class)
                 .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))//h2-console 정상 작동용
+                .exceptionHandling(exception -> {
+                    exception.authenticationEntryPoint(authenticationEntryPoint);
+                })
                 .oauth2Login(
                         oauth2Login             ->
                         {
@@ -46,6 +52,7 @@ public class SecurityConfig {
     }
 
     private void needAuthenticated(AuthorizeHttpRequestsConfigurer<?>.AuthorizationManagerRequestMatcherRegistry req, String pattern){
+        req.requestMatchers(HttpMethod.GET,  pattern).authenticated();
         req.requestMatchers(HttpMethod.POST,  pattern).authenticated();
         req.requestMatchers(HttpMethod.PUT,  pattern).authenticated();
         req.requestMatchers(HttpMethod.PATCH,  pattern).authenticated();

--- a/backend/src/main/java/com/NBE3_4_2_Team4/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/global/config/SecurityConfig.java
@@ -34,6 +34,12 @@ public class SecurityConfig {
                         })
                 .addFilterBefore(customJwtFilter, UsernamePasswordAuthenticationFilter.class)
                 .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))//h2-console 정상 작동용
+                .oauth2Login(
+                        _             ->
+                        {
+
+                        }
+                )
         ;
         return http.build();
     }

--- a/backend/src/main/java/com/NBE3_4_2_Team4/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/global/config/SecurityConfig.java
@@ -13,6 +13,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -38,6 +39,7 @@ public class SecurityConfig {
                         needAuthenticated(req, "/api/products/**");
                         req.anyRequest().permitAll();
                         })
+                .sessionManagement(c -> c.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .addFilterBefore(customJwtFilter, UsernamePasswordAuthenticationFilter.class)
                 .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))//h2-console 정상 작동용
                 .exceptionHandling(exception -> {

--- a/backend/src/main/java/com/NBE3_4_2_Team4/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/global/config/SecurityConfig.java
@@ -37,6 +37,7 @@ public class SecurityConfig {
                         needAuthenticated(req, "/api/questions/**");
                         needAuthenticated(req, "/api/answers/**");
                         needAuthenticated(req, "/api/products/**");
+                        req.requestMatchers(HttpMethod.POST, "/api/logout").authenticated();
                         req.anyRequest().permitAll();
                         })
                 .sessionManagement(c -> c.sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/backend/src/main/java/com/NBE3_4_2_Team4/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/global/config/SecurityConfig.java
@@ -62,7 +62,6 @@ public class SecurityConfig {
     }
 
     private void needAuthenticated(AuthorizeHttpRequestsConfigurer<?>.AuthorizationManagerRequestMatcherRegistry req, String pattern){
-        req.requestMatchers(HttpMethod.GET,  pattern).authenticated();
         req.requestMatchers(HttpMethod.POST,  pattern).authenticated();
         req.requestMatchers(HttpMethod.PUT,  pattern).authenticated();
         req.requestMatchers(HttpMethod.PATCH,  pattern).authenticated();

--- a/backend/src/main/java/com/NBE3_4_2_Team4/global/security/AuthManager.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/global/security/AuthManager.java
@@ -24,7 +24,7 @@ public class AuthManager {
 
     public static Member getMemberFromContext(){
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if(authentication != null){
+        if(authentication != null && authentication.getPrincipal() instanceof CustomUser){
             return ((CustomUser) authentication.getPrincipal()).getMember();
         }else {
             return null;

--- a/backend/src/main/java/com/NBE3_4_2_Team4/global/security/AuthManager.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/global/security/AuthManager.java
@@ -9,7 +9,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
 @Component
-public class AuthHandler {
+public class AuthManager {
     public void setLogin(Member member){
         UserDetails userDetails = new CustomUser(member);
 
@@ -20,5 +20,14 @@ public class AuthHandler {
         );
 
         SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    public static Member getMemberFromContext(){
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if(authentication != null){
+            return ((CustomUser) authentication.getPrincipal()).getMember();
+        }else {
+            return null;
+        }
     }
 }

--- a/backend/src/main/java/com/NBE3_4_2_Team4/global/security/HttpManager.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/global/security/HttpManager.java
@@ -49,4 +49,9 @@ public class HttpManager {
         cookie.setMaxAge(0); // 쿠키 만료 시간 (초 단위)
         resp.addCookie(cookie); // 응답에 쿠키 추가
     }
+
+    public void expireJwtCookie(
+            HttpServletResponse resp){
+        deleteCookie(resp, "accessToken");
+    }
 }

--- a/backend/src/main/java/com/NBE3_4_2_Team4/global/security/HttpManager.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/global/security/HttpManager.java
@@ -22,6 +22,11 @@ public class HttpManager {
         resp.addCookie(cookie); // 응답에 쿠키 추가
     }
 
+    public void setJwtCookie(
+            HttpServletResponse resp, String jwtToken, int minute){
+        this.setCookie(resp, "accessToken", jwtToken, minute);
+    }
+
     public String getCookieValue(
             HttpServletRequest req, String name) {
         return Optional

--- a/backend/src/main/java/com/NBE3_4_2_Team4/global/security/accessDeniedHandler/CustomAccessDeniedHandler.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/global/security/accessDeniedHandler/CustomAccessDeniedHandler.java
@@ -1,4 +1,4 @@
-package com.NBE3_4_2_Team4.global.security.authenticationEntryPoint;
+package com.NBE3_4_2_Team4.global.security.accessDeniedHandler;
 
 import com.NBE3_4_2_Team4.global.rsData.RsData;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -6,8 +6,8 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -15,13 +15,13 @@ import java.nio.charset.StandardCharsets;
 
 @Component
 @RequiredArgsConstructor
-public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
     private final ObjectMapper objectMapper;
 
     @Override
-    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
         // RsData 형식의 JSON 응답 생성
-        RsData<String> responseData = new RsData<>("401-1", "Unauthorized", "인증이 필요합니다.");
+        RsData<String> responseData = new RsData<>("403-1", "Forbidden", "권한이 부족합니다.");
 
         // 응답 설정
         response.setContentType("application/json");

--- a/backend/src/main/java/com/NBE3_4_2_Team4/global/security/accessDeniedHandler/CustomAccessDeniedHandler.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/global/security/accessDeniedHandler/CustomAccessDeniedHandler.java
@@ -26,7 +26,7 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
         // 응답 설정
         response.setContentType("application/json");
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
 
         // JSON 변환 후 응답에 작성
         String jsonResponse = objectMapper.writeValueAsString(responseData);

--- a/backend/src/main/java/com/NBE3_4_2_Team4/global/security/authenticationEntryPoint/CustomAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/global/security/authenticationEntryPoint/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,18 @@
+package com.NBE3_4_2_Team4.global.security.authenticationEntryPoint;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+}

--- a/backend/src/main/java/com/NBE3_4_2_Team4/global/security/authenticationEntryPoint/CustomAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/global/security/authenticationEntryPoint/CustomAuthenticationEntryPoint.java
@@ -1,5 +1,7 @@
 package com.NBE3_4_2_Team4.global.security.authenticationEntryPoint;
 
+import com.NBE3_4_2_Team4.global.rsData.RsData;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -8,11 +10,24 @@ import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 @Component
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
-        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+        // RsData 형식의 JSON 응답 생성
+        RsData<String> responseData = new RsData<>("401-1", "Unauthorized", "인증이 필요합니다.");
+
+        // 응답 설정
+        response.setContentType("application/json");
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        // JSON 변환 후 응답에 작성
+        String jsonResponse = objectMapper.writeValueAsString(responseData);
+        response.getWriter().write(jsonResponse);
     }
 }

--- a/backend/src/main/java/com/NBE3_4_2_Team4/global/security/filter/CustomJwtFilter.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/global/security/filter/CustomJwtFilter.java
@@ -1,6 +1,6 @@
 package com.NBE3_4_2_Team4.global.security.filter;
 
-import com.NBE3_4_2_Team4.global.security.AuthHandler;
+import com.NBE3_4_2_Team4.global.security.AuthManager;
 import com.NBE3_4_2_Team4.global.security.jwt.JwtManager;
 import com.NBE3_4_2_Team4.domain.member.member.entity.Member;
 import com.NBE3_4_2_Team4.global.security.jwt.JwtObjectMapper;
@@ -10,17 +10,19 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.Map;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class CustomJwtFilter extends OncePerRequestFilter {
     private final JwtManager jwtManager;
-    private final AuthHandler authHandler;
+    private final AuthManager authManager;
     private final JwtObjectMapper jwtObjectMapper;
 
     private String getJwtToken(HttpServletRequest request) {
@@ -47,7 +49,7 @@ public class CustomJwtFilter extends OncePerRequestFilter {
         Member member = jwtObjectMapper.getMemberByJwtClaims(claims);
 
         if (member != null) {
-            authHandler.setLogin(member);
+            authManager.setLogin(member);
         }
 
         filterChain.doFilter(request, response);

--- a/backend/src/main/java/com/NBE3_4_2_Team4/global/security/oauth2/CustomOAuth2RequestResolver.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/global/security/oauth2/CustomOAuth2RequestResolver.java
@@ -1,0 +1,49 @@
+package com.NBE3_4_2_Team4.global.security.oauth2;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+@Component
+public class CustomOAuth2RequestResolver implements OAuth2AuthorizationRequestResolver {
+    private final DefaultOAuth2AuthorizationRequestResolver defaultResolver;
+
+    public CustomOAuth2RequestResolver(ClientRegistrationRepository clientRegistrationRepository) {
+        this.defaultResolver = new DefaultOAuth2AuthorizationRequestResolver(clientRegistrationRepository, "/oauth2/authorization");
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+        OAuth2AuthorizationRequest authorizationRequest = defaultResolver.resolve(request);
+        return customizeAuthorizationRequest(authorizationRequest, request);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
+        OAuth2AuthorizationRequest authorizationRequest = defaultResolver.resolve(request, clientRegistrationId);
+        return customizeAuthorizationRequest(authorizationRequest, request);
+    }
+
+    private OAuth2AuthorizationRequest customizeAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request) {
+        if (authorizationRequest == null || request == null) {
+            return null;
+        }
+
+        String redirectUrl = request.getParameter("redirectUrl");
+
+        Map<String, Object> additionalParameters = new HashMap<>(authorizationRequest.getAdditionalParameters());
+        if (redirectUrl != null && !redirectUrl.isEmpty()) {
+            additionalParameters.put("state", redirectUrl);
+        }
+
+        return OAuth2AuthorizationRequest.from(authorizationRequest)
+                .additionalParameters(additionalParameters)
+                .state(redirectUrl)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/NBE3_4_2_Team4/global/security/oauth2/CustomOAuth2RequestResolver.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/global/security/oauth2/CustomOAuth2RequestResolver.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+
 @Component
 public class CustomOAuth2RequestResolver implements OAuth2AuthorizationRequestResolver {
     private final DefaultOAuth2AuthorizationRequestResolver defaultResolver;
@@ -34,10 +36,10 @@ public class CustomOAuth2RequestResolver implements OAuth2AuthorizationRequestRe
             return null;
         }
 
-        String redirectUrl = request.getParameter("redirectUrl");
+        String redirectUrl = Objects.requireNonNullElse(request.getParameter("redirectUrl"), "http://localhost:3000/");
 
         Map<String, Object> additionalParameters = new HashMap<>(authorizationRequest.getAdditionalParameters());
-        if (redirectUrl != null && !redirectUrl.isEmpty()) {
+        if (!redirectUrl.isEmpty()) {
             additionalParameters.put("state", redirectUrl);
         }
 

--- a/backend/src/main/java/com/NBE3_4_2_Team4/global/security/oauth2/CustomOAuth2SuccessHandler.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/global/security/oauth2/CustomOAuth2SuccessHandler.java
@@ -1,8 +1,6 @@
 package com.NBE3_4_2_Team4.global.security.oauth2;
 
 import com.NBE3_4_2_Team4.domain.member.member.entity.Member;
-import com.NBE3_4_2_Team4.domain.member.member.repository.MemberRepository;
-import com.NBE3_4_2_Team4.domain.member.member.service.MemberService;
 import com.NBE3_4_2_Team4.global.security.HttpManager;
 import com.NBE3_4_2_Team4.global.security.jwt.JwtManager;
 import com.NBE3_4_2_Team4.global.security.user.CustomUser;
@@ -15,7 +13,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
-import java.security.Principal;
 
 @Slf4j
 @Component
@@ -31,8 +28,8 @@ public class CustomOAuth2SuccessHandler extends SavedRequestAwareAuthenticationS
         Member member = customUser.getMember();
         String token = jwtManager.generateToken(member);
         httpManager.setJwtCookie(resp, token, 30);
-        String redirectUrl = "localhost:8080";
-//        String redirectUrl = req.getParameter("state");
-        resp.sendRedirect(redirectUrl);
+        String targetUrl = "http://localhost:8080";
+        setDefaultTargetUrl(targetUrl);
+        super.onAuthenticationSuccess(req, resp, auth);
     }
 }

--- a/backend/src/main/java/com/NBE3_4_2_Team4/global/security/oauth2/CustomOAuth2SuccessHandler.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/global/security/oauth2/CustomOAuth2SuccessHandler.java
@@ -28,7 +28,7 @@ public class CustomOAuth2SuccessHandler extends SavedRequestAwareAuthenticationS
         Member member = customUser.getMember();
         String token = jwtManager.generateToken(member);
         httpManager.setJwtCookie(resp, token, 30);
-        String targetUrl = "http://localhost:8080";
+        String targetUrl = req.getParameter("state");
         setDefaultTargetUrl(targetUrl);
         super.onAuthenticationSuccess(req, resp, auth);
     }

--- a/backend/src/main/java/com/NBE3_4_2_Team4/global/security/oauth2/CustomOAuth2SuccessHandler.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/global/security/oauth2/CustomOAuth2SuccessHandler.java
@@ -21,7 +21,6 @@ import java.security.Principal;
 @Component
 @RequiredArgsConstructor
 public class CustomOAuth2SuccessHandler extends SavedRequestAwareAuthenticationSuccessHandler {
-    private final MemberRepository memberRepository;
     private final JwtManager jwtManager;
     private final HttpManager httpManager;
 
@@ -29,7 +28,7 @@ public class CustomOAuth2SuccessHandler extends SavedRequestAwareAuthenticationS
     @Override
     public void onAuthenticationSuccess(HttpServletRequest req, HttpServletResponse resp, Authentication auth) {
         CustomUser customUser = (CustomUser) auth.getPrincipal();
-        Member member = memberRepository.findById(customUser.getId()).orElseThrow();
+        Member member = customUser.getMember();
         String token = jwtManager.generateToken(member);
         httpManager.setJwtCookie(resp, token, 30);
         String redirectUrl = "localhost:8080";

--- a/backend/src/main/java/com/NBE3_4_2_Team4/global/security/oauth2/CustomOAuth2SuccessHandler.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/global/security/oauth2/CustomOAuth2SuccessHandler.java
@@ -1,0 +1,39 @@
+package com.NBE3_4_2_Team4.global.security.oauth2;
+
+import com.NBE3_4_2_Team4.domain.member.member.entity.Member;
+import com.NBE3_4_2_Team4.domain.member.member.repository.MemberRepository;
+import com.NBE3_4_2_Team4.domain.member.member.service.MemberService;
+import com.NBE3_4_2_Team4.global.security.HttpManager;
+import com.NBE3_4_2_Team4.global.security.jwt.JwtManager;
+import com.NBE3_4_2_Team4.global.security.user.CustomUser;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SavedRequestAwareAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.security.Principal;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomOAuth2SuccessHandler extends SavedRequestAwareAuthenticationSuccessHandler {
+    private final MemberRepository memberRepository;
+    private final JwtManager jwtManager;
+    private final HttpManager httpManager;
+
+    @SneakyThrows
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest req, HttpServletResponse resp, Authentication auth) {
+        CustomUser customUser = (CustomUser) auth.getPrincipal();
+        Member member = memberRepository.findById(customUser.getId()).orElseThrow();
+        String token = jwtManager.generateToken(member);
+        httpManager.setJwtCookie(resp, token, 30);
+        String redirectUrl = "localhost:8080";
+//        String redirectUrl = req.getParameter("state");
+        resp.sendRedirect(redirectUrl);
+    }
+}

--- a/backend/src/main/java/com/NBE3_4_2_Team4/global/security/oauth2/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/global/security/oauth2/CustomOAuth2UserService.java
@@ -14,7 +14,7 @@ import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
-public class OAuth2UserService extends DefaultOAuth2UserService {
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private final MemberService memberService;
 
     @Override

--- a/backend/src/main/java/com/NBE3_4_2_Team4/global/security/user/CustomUser.java
+++ b/backend/src/main/java/com/NBE3_4_2_Team4/global/security/user/CustomUser.java
@@ -11,28 +11,11 @@ import java.util.Map;
 
 @Getter
 public class CustomUser extends User implements OAuth2User {
-    private final long id;
-
-    private final String nickname;
-
-    public CustomUser(
-            long id,
-            String username,
-            String password,
-            String nickname,
-            Collection<? extends GrantedAuthority> authorities) {
-        super(username, password, authorities);
-        this.id = id;
-        this.nickname = nickname;
-    }
+    private final Member member;
 
     public CustomUser(Member member){
-        this(
-                member.getId(),
-                member.getUsername(),
-                member.getPassword(),
-                member.getNickname(),
-                member.getAuthorities());
+        super(member.getUsername(), member.getPassword(), member.getAuthorities());
+        this.member = member;
     }
 
     @Override

--- a/backend/src/test/java/com/NBE3_4_2_Team4/domain/member/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/NBE3_4_2_Team4/domain/member/member/controller/MemberControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -23,7 +24,8 @@ public class MemberControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Test
     void loginSuccessTest() throws Exception {
@@ -35,8 +37,9 @@ public class MemberControllerTest {
         String requestBody = objectMapper.writeValueAsString(loginRequestDto);
 
         mockMvc.perform(post("/api/login")
-                .content(requestBody)
-                .contentType(MediaType.APPLICATION_JSON))
+                        .with(csrf())
+                        .content(requestBody)
+                        .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andDo(print());
     }
@@ -51,6 +54,7 @@ public class MemberControllerTest {
         String requestBody = objectMapper.writeValueAsString(loginRequestDto);
 
         mockMvc.perform(post("/api/login")
+                        .with(csrf())
                         .content(requestBody)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound())
@@ -67,6 +71,7 @@ public class MemberControllerTest {
         String requestBody = objectMapper.writeValueAsString(loginRequestDto);
 
         mockMvc.perform(post("/api/login")
+                        .with(csrf())
                         .content(requestBody)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest())

--- a/backend/src/test/java/com/NBE3_4_2_Team4/domain/member/member/service/MemberInitDataTest.java
+++ b/backend/src/test/java/com/NBE3_4_2_Team4/domain/member/member/service/MemberInitDataTest.java
@@ -1,6 +1,5 @@
 package com.NBE3_4_2_Team4.domain.member.member.service;
 
-import com.NBE3_4_2_Team4.domain.member.dto.request.LoginRequestDto;
 import com.NBE3_4_2_Team4.domain.member.member.entity.Member;
 import com.NBE3_4_2_Team4.domain.member.member.repository.MemberRepository;
 import jakarta.transaction.Transactional;
@@ -16,11 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @ActiveProfiles("test")
 @SpringBootTest
 @Transactional
-class MemberServiceTest {
-
-    @Autowired
-    private MemberService memberService;
-
+class MemberInitDataTest {
     @Autowired
     private MemberRepository memberRepository;
 

--- a/backend/src/test/java/com/NBE3_4_2_Team4/domain/member/member/service/MemberInitDataTest.java
+++ b/backend/src/test/java/com/NBE3_4_2_Team4/domain/member/member/service/MemberInitDataTest.java
@@ -26,5 +26,6 @@ class MemberInitDataTest {
         Member admin = memberRepository.findByUsername("admin@test.com").orElseThrow();
         assertNotNull(admin);
         assertEquals("관리자", admin.getNickname());
+        assertEquals(Member.Role.ADMIN, admin.getRole());
     }
 }

--- a/backend/src/test/java/com/NBE3_4_2_Team4/global/security/filter/CustomJwtFilterTest.java
+++ b/backend/src/test/java/com/NBE3_4_2_Team4/global/security/filter/CustomJwtFilterTest.java
@@ -13,6 +13,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
@@ -118,5 +119,25 @@ public class CustomJwtFilterTest {
                         .with(csrf())
                 )
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    public void testCustomJwtFilter8() throws Exception {
+        String jwtToken = jwtManager.generateToken(member);
+
+        mockMvc.perform(post("/api/logout")
+                        .header("Authorization", String.format("Bearer %s", jwtToken))
+                        .with(csrf())
+                )
+                .andExpect(status().isNoContent())
+                .andDo(print());
+    }
+
+    @Test
+    public void testCustomJwtFilter9() throws Exception {
+        mockMvc.perform(post("/api/logout")
+                        .with(csrf())
+                )
+                .andExpect(status().isUnauthorized());
     }
 }

--- a/backend/src/test/java/com/NBE3_4_2_Team4/global/security/filter/CustomJwtFilterTest.java
+++ b/backend/src/test/java/com/NBE3_4_2_Team4/global/security/filter/CustomJwtFilterTest.java
@@ -1,9 +1,11 @@
 package com.NBE3_4_2_Team4.global.security.filter;
 
 import com.NBE3_4_2_Team4.domain.member.member.entity.Member;
+import com.NBE3_4_2_Team4.global.security.AuthManager;
 import com.NBE3_4_2_Team4.global.security.jwt.JwtManager;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -51,6 +53,7 @@ public class CustomJwtFilterTest {
     }
 
     @Test
+    @DisplayName("필터 안 걸려있는 url 에 대한 post 테스트")
     public void testCustomJwtFilter1() throws Exception {
         mockMvc.perform(post("/api/test")
                         .with(csrf())
@@ -59,6 +62,7 @@ public class CustomJwtFilterTest {
     }
 
     @Test
+    @DisplayName("필터 걸려있는 url - products/test 에 대한 post 테스트 - 헤더에 JWT 없는 경우 (인증 실패)")
     public void testCustomJwtFilter2() throws Exception {
         mockMvc.perform(post("/api/products/test")
                         .with(csrf())
@@ -67,6 +71,7 @@ public class CustomJwtFilterTest {
     }
 
     @Test
+    @DisplayName("필터 걸려있는 url - products/test 에 대한 post 테스트 - 헤더에 JWT 있는 경우 (인증 성공)")
     public void testCustomJwtFilter3() throws Exception {
         String jwtToken = jwtManager.generateToken(member);
 
@@ -78,6 +83,7 @@ public class CustomJwtFilterTest {
     }
 
     @Test
+    @DisplayName("필터 걸려있는 url - questions/test 에 대한 post 테스트 - 헤더에 JWT 있는 경우 (인증 성공)")
     public void testCustomJwtFilter4() throws Exception {
         String jwtToken = jwtManager.generateToken(member);
 
@@ -89,6 +95,7 @@ public class CustomJwtFilterTest {
     }
 
     @Test
+    @DisplayName("필터 걸려있는 url - answers/test 에 대한 post 테스트 - 헤더에 JWT 있는 경우 (인증 성공)")
     public void testCustomJwtFilter5() throws Exception {
         String jwtToken = jwtManager.generateToken(member);
 
@@ -100,7 +107,18 @@ public class CustomJwtFilterTest {
     }
 
     @Test
+    @DisplayName("필터 걸려있는 url - admin/test 에 대한 post 테스트 - 헤더에 JWT 없는 경우 (인증 실패)")
     public void testCustomJwtFilter6() throws Exception {
+
+        mockMvc.perform(post("/api/admin/test")
+                        .with(csrf())
+                )
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("필터 걸려있는 url - admin/test 에 대한 post 테스트 - 헤더에 일반 유저의 JWT 있는 경우 (인증 성공, 인가 실패)")
+    public void testCustomJwtFilter7() throws Exception {
         String jwtToken = jwtManager.generateToken(member);
 
         mockMvc.perform(post("/api/admin/test")
@@ -111,7 +129,8 @@ public class CustomJwtFilterTest {
     }
 
     @Test
-    public void testCustomJwtFilter7() throws Exception {
+    @DisplayName("필터 걸려있는 url - admin/test 에 대한 post 테스트 - 헤더에 관리자의 JWT 있는 경우 (인증, 인가 성공)")
+    public void testCustomJwtFilter8() throws Exception {
         String jwtToken = jwtManager.generateToken(admin);
 
         mockMvc.perform(post("/api/admin/test")
@@ -122,7 +141,8 @@ public class CustomJwtFilterTest {
     }
 
     @Test
-    public void testCustomJwtFilter8() throws Exception {
+    @DisplayName("로그아웃 성공 테스트 - 헤더에 사용자의 JWT 있는 경우")
+    public void testCustomJwtFilter9() throws Exception {
         String jwtToken = jwtManager.generateToken(member);
 
         mockMvc.perform(post("/api/logout")
@@ -134,7 +154,8 @@ public class CustomJwtFilterTest {
     }
 
     @Test
-    public void testCustomJwtFilter9() throws Exception {
+    @DisplayName("로그아웃 실패 테스트 - 헤더에 사용자의 JWT 없는 경우 (로그인 되어 있지 않은 경우)")
+    public void testCustomJwtFilter10() throws Exception {
         mockMvc.perform(post("/api/logout")
                         .with(csrf())
                 )

--- a/backend/src/test/java/com/NBE3_4_2_Team4/global/security/filter/CustomJwtFilterTest.java
+++ b/backend/src/test/java/com/NBE3_4_2_Team4/global/security/filter/CustomJwtFilterTest.java
@@ -10,6 +10,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -49,14 +51,18 @@ public class CustomJwtFilterTest {
 
     @Test
     public void testCustomJwtFilter1() throws Exception {
-        mockMvc.perform(post("/api/test"))
+        mockMvc.perform(post("/api/test")
+                        .with(csrf())
+                )
                 .andExpect(status().isOk());
     }
 
     @Test
     public void testCustomJwtFilter2() throws Exception {
-        mockMvc.perform(post("/api/products/test"))
-                .andExpect(status().isForbidden());
+        mockMvc.perform(post("/api/products/test")
+                        .with(csrf())
+                )
+                .andExpect(status().isUnauthorized());
     }
 
     @Test
@@ -64,7 +70,9 @@ public class CustomJwtFilterTest {
         String jwtToken = jwtManager.generateToken(member);
 
         mockMvc.perform(post("/api/products/test")
-                        .header("Authorization", String.format("Bearer %s", jwtToken)))
+                        .header("Authorization", String.format("Bearer %s", jwtToken))
+                        .with(csrf())
+                )
                 .andExpect(status().isOk());
     }
 
@@ -73,7 +81,9 @@ public class CustomJwtFilterTest {
         String jwtToken = jwtManager.generateToken(member);
 
         mockMvc.perform(post("/api/questions/test")
-                        .header("Authorization", String.format("Bearer %s", jwtToken)))
+                        .header("Authorization", String.format("Bearer %s", jwtToken))
+                        .with(csrf())
+                )
                 .andExpect(status().isOk());
     }
 
@@ -82,7 +92,9 @@ public class CustomJwtFilterTest {
         String jwtToken = jwtManager.generateToken(member);
 
         mockMvc.perform(post("/api/answers/test")
-                        .header("Authorization", String.format("Bearer %s", jwtToken)))
+                        .header("Authorization", String.format("Bearer %s", jwtToken))
+                        .with(csrf())
+                )
                 .andExpect(status().isOk());
     }
 
@@ -91,7 +103,9 @@ public class CustomJwtFilterTest {
         String jwtToken = jwtManager.generateToken(member);
 
         mockMvc.perform(post("/api/admin/test")
-                        .header("Authorization", String.format("Bearer %s", jwtToken)))
+                        .header("Authorization", String.format("Bearer %s", jwtToken))
+                        .with(csrf())
+                )
                 .andExpect(status().isForbidden());
     }
 
@@ -100,7 +114,9 @@ public class CustomJwtFilterTest {
         String jwtToken = jwtManager.generateToken(admin);
 
         mockMvc.perform(post("/api/admin/test")
-                        .header("Authorization", String.format("Bearer %s", jwtToken)))
+                        .header("Authorization", String.format("Bearer %s", jwtToken))
+                        .with(csrf())
+                )
                 .andExpect(status().isOk());
     }
 }


### PR DESCRIPTION
## 🪐 작업 내용
<!-- 작업한 내용에 대해 설명해주세요. -->
1.  카카오의 OAuth2 로그인 로직을 구현했습니다.
* 세션 기반 인증을 비활성화 하고, OAuth2 로그인 성공 시에도 JWT를 발급하는 식으로 인증을 처리했습니다.
* 로그아웃의 경우 현재 JWT만 초기화하는 식으로 구현돼있습니다. - 추후 토큰 만료로 인한 로그아웃이 아닌 사용자가 직접 로그아웃할 경우 카카오 자체도 로그아웃 되도록 변경하겠습니다.

2. SecurityContext 내에 있는 Member 를 가져오는 매서드는

``` java
Member member = AuthManager.getMemberFromContext();
//로그인이 안 돼있을 경우 null 반환
```
를 사용하시면 됩니다. static 매서드라 바로 호출하셔도 됩니다.


## 📚 Reference
<!-- 참고할만한 자료가 있으면 올려주세요.  -->

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
